### PR TITLE
Added `make install` in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -74,7 +74,7 @@ recent version from git and build from source on your hardware.
 4. Make and check the build (you can also use `make check` to only run
    test suite):
 
-        make && make distcheck
+        make && make distcheck && make install
 
 
 Contact us


### PR DESCRIPTION
Without `make install` libcouchbase files are not copied to standard system folders thus `npm install couchbase` fails.
