### PR TITLE
Fix to support compiling under VS2015 VC140

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ Makefile.am
 packaging/distinfo/distinfo.cmake
 packaging/distinfo/MANIFEST
 *.tlog
+*.nupkg
+*.suo

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ configure.ac
 Makefile.am
 packaging/distinfo/distinfo.cmake
 packaging/distinfo/MANIFEST
+*.tlog

--- a/packaging/nuget/libcouchbase.autopkg
+++ b/packaging/nuget/libcouchbase.autopkg
@@ -1,0 +1,76 @@
+configurations 
+{
+    // This node contains custom pivot information.
+    Toolset 
+    {
+        key : "PlatformToolset"; // this is CoApp pre-defined key
+        choices: { v140, v120, v110, v100 };
+    };
+};
+nuget {
+    nuspec {
+        id = libcouchbase.v140.windesktop.static.rt-dyn;
+        version : ${VERSION};
+        title : Couchbase C SDK Library v140;
+        authors : Couchbase;
+        owners : Couchbase;
+        licenseUrl : "https://github.com/couchbase/libcouchbase/blob/master/LICENSE";
+        projectUrl: "https://github.com/couchbase/libcouchbase";
+        iconUrl: "http://www.couchbase.com/images/couchbase_favicon_0.ico";
+        requireLicenseAcceptance:false;
+        summary: @"Couchbase C SDK vc140 libraries";
+
+        description: @"The Couchbase C SDK provides a fast, callback-based API for interacting with your Couchbase cluster.
+It operates as a single threaded asynchronous I/O library that can be optionally integrated with an existing asynchronous application.
+It can also run standalone within a traditional synchronous or threaded application as well.
+The SDK is cross-platform and can be used on Linux, Mac OS X, or Windows.";
+
+        releaseNotes: "http://developer.couchbase.com/documentation/server/current/sdks/c-2.4/release-notes.html";
+
+        copyright: "© 2016 COUCHBASE All rights reserved.";
+        tags: { native, cpp, protobuf, serialization };
+    };
+
+    files {
+//		#defines {
+//			SDK_ROOT = ..\..\;
+//		};
+
+//		nestedInclude: {
+//			#destination : ${d_include}libcouchbase;
+//			"${SDK_ROOT}include\libcouchbase\**\*.h*";
+//		};
+
+//		include += {
+//			"include\**\*.h";
+//		};
+
+//        [x64,v140,release] { 
+//            lib: { ${SDK_ROOT}build_x64\lib\RelWithDebInfo\libcouchbase.lib };
+//			bin: { ${SDK_ROOT}build_x64\bin\RelWithDebInfo\libcouchbase.dll };
+//			symbols: { ${SDK_ROOT}build_x64\bin\RelWithDebInfo\libcouchbase.pdb };
+//        }
+
+//        [x64,v140,debug] { 
+//            lib: { ${SDK_ROOT}build_x64\lib\Debug\libcouchbase_d.lib };
+//			bin: { ${SDK_ROOT}build_x64\bin\Debug\libcouchbase_d.dll };
+//			symbols: { ${SDK_ROOT}build_x64\bin\Debug\libcouchbase_d.pdb };
+//        }
+
+//        [win32,v140,release] { 
+//            lib: { ${SDK_ROOT}build_x86\lib\RelWithDebInfo\libcouchbase.lib };
+//			bin: { ${SDK_ROOT}build_x86\bin\RelWithDebInfo\libcouchbase.dll };
+//			symbols: { ${SDK_ROOT}build_x86\bin\RelWithDebInfo\libcouchbase.pdb };
+//        }
+
+//        [win32,v140,debug] { 
+//            lib: { ${SDK_ROOT}build_x86\lib\Debug\libcouchbase_d.lib };
+//			bin: { ${SDK_ROOT}build_x86\bin\Debug\libcouchbase_d.dll };
+//			symbols: { ${SDK_ROOT}build_x86\bin\Debug\libcouchbase_d.pdb };
+//        }
+    };
+
+	targets {
+		Defines += HAS_LIBCOUCHBASE;
+	};
+}

--- a/packaging/nuget/libcouchbase.autopkg
+++ b/packaging/nuget/libcouchbase.autopkg
@@ -40,8 +40,11 @@ The SDK is cross-platform and can be used on Linux, Mac OS X, or Windows.";
 			#destination : ${d_include}libcouchbase;
 			"${SDK_ROOT}include\libcouchbase\**\*.h*";
 		};
-
-
+		nestedInclude += {
+			#destination : ${d_include}libcouchbase;
+			"${SDK_ROOT}build_v140_x64\generated\libcouchbase\*.h"
+		};
+		
         [x64,v140,release] { 
             lib: { ${SDK_ROOT}build_v140_x64\lib\RelWithDebInfo\libcouchbase.lib };
 			bin: { ${SDK_ROOT}build_v140_x64\bin\RelWithDebInfo\libcouchbase.dll };

--- a/packaging/nuget/libcouchbase.autopkg
+++ b/packaging/nuget/libcouchbase.autopkg
@@ -4,20 +4,20 @@ configurations
     Toolset 
     {
         key : "PlatformToolset"; // this is CoApp pre-defined key
-        choices: { v140, v120, v110, v100 };
+        choices: { v140 };
     };
 };
 nuget {
     nuspec {
         id = libcouchbase.v140.windesktop.static.rt-dyn;
-        version : ${VERSION};
-        title : Couchbase C SDK Library v140;
-        authors : Couchbase;
-        owners : Couchbase;
+        version : 2.5.8.1;
+        title : "Couchbase C SDK Library v140";
+        authors : "Couchbase";
+        owners : "Couchbase";
         licenseUrl : "https://github.com/couchbase/libcouchbase/blob/master/LICENSE";
         projectUrl: "https://github.com/couchbase/libcouchbase";
         iconUrl: "http://www.couchbase.com/images/couchbase_favicon_0.ico";
-        requireLicenseAcceptance:false;
+        requireLicenseAcceptance: false;
         summary: @"Couchbase C SDK vc140 libraries";
 
         description: @"The Couchbase C SDK provides a fast, callback-based API for interacting with your Couchbase cluster.
@@ -27,47 +27,44 @@ The SDK is cross-platform and can be used on Linux, Mac OS X, or Windows.";
 
         releaseNotes: "http://developer.couchbase.com/documentation/server/current/sdks/c-2.4/release-notes.html";
 
-        copyright: "© 2016 COUCHBASE All rights reserved.";
-        tags: { native, cpp, protobuf, serialization };
+        copyright: "Copyright 2016 COUCHBASE All rights reserved.";
+
+        tags: { native, c, cpp, couchbase };
     };
 
     files {
-//		#defines {
-//			SDK_ROOT = ..\..\;
-//		};
+		#defines {
+			SDK_ROOT = ..\..\;
+		};
+		nestedInclude: {
+			#destination : ${d_include}libcouchbase;
+			"${SDK_ROOT}include\libcouchbase\**\*.h*";
+		};
 
-//		nestedInclude: {
-//			#destination : ${d_include}libcouchbase;
-//			"${SDK_ROOT}include\libcouchbase\**\*.h*";
-//		};
 
-//		include += {
-//			"include\**\*.h";
-//		};
+        [x64,v140,release] { 
+            lib: { ${SDK_ROOT}build_v140_x64\lib\RelWithDebInfo\libcouchbase.lib };
+			bin: { ${SDK_ROOT}build_v140_x64\bin\RelWithDebInfo\libcouchbase.dll };
+			symbols: { ${SDK_ROOT}build_v140_x64\bin\RelWithDebInfo\libcouchbase.pdb };
+        };
 
-//        [x64,v140,release] { 
-//            lib: { ${SDK_ROOT}build_x64\lib\RelWithDebInfo\libcouchbase.lib };
-//			bin: { ${SDK_ROOT}build_x64\bin\RelWithDebInfo\libcouchbase.dll };
-//			symbols: { ${SDK_ROOT}build_x64\bin\RelWithDebInfo\libcouchbase.pdb };
-//        }
+        [x64,v140,debug] { 
+            lib: { ${SDK_ROOT}build_v140_x64\lib\Debug\libcouchbase_d.lib };
+			bin: { ${SDK_ROOT}build_v140_x64\bin\Debug\libcouchbase_d.dll };
+			symbols: { ${SDK_ROOT}build_v140_x64\bin\Debug\libcouchbase_d.pdb };
+        };
 
-//        [x64,v140,debug] { 
-//            lib: { ${SDK_ROOT}build_x64\lib\Debug\libcouchbase_d.lib };
-//			bin: { ${SDK_ROOT}build_x64\bin\Debug\libcouchbase_d.dll };
-//			symbols: { ${SDK_ROOT}build_x64\bin\Debug\libcouchbase_d.pdb };
-//        }
+        [win32,v140,release] { 
+            lib: { ${SDK_ROOT}build_v140_x86\lib\RelWithDebInfo\libcouchbase.lib };
+			bin: { ${SDK_ROOT}build_v140_x86\bin\RelWithDebInfo\libcouchbase.dll };
+			symbols: { ${SDK_ROOT}build_v140_x86\bin\RelWithDebInfo\libcouchbase.pdb };
+        };
 
-//        [win32,v140,release] { 
-//            lib: { ${SDK_ROOT}build_x86\lib\RelWithDebInfo\libcouchbase.lib };
-//			bin: { ${SDK_ROOT}build_x86\bin\RelWithDebInfo\libcouchbase.dll };
-//			symbols: { ${SDK_ROOT}build_x86\bin\RelWithDebInfo\libcouchbase.pdb };
-//        }
-
-//        [win32,v140,debug] { 
-//            lib: { ${SDK_ROOT}build_x86\lib\Debug\libcouchbase_d.lib };
-//			bin: { ${SDK_ROOT}build_x86\bin\Debug\libcouchbase_d.dll };
-//			symbols: { ${SDK_ROOT}build_x86\bin\Debug\libcouchbase_d.pdb };
-//        }
+        [win32,v140,debug] { 
+            lib: { ${SDK_ROOT}build_v140_x86\lib\Debug\libcouchbase_d.lib };
+			bin: { ${SDK_ROOT}build_v140_x86\bin\Debug\libcouchbase_d.dll };
+			symbols: { ${SDK_ROOT}build_v140_x86\bin\Debug\libcouchbase_d.pdb };
+        };
     };
 
 	targets {

--- a/tools/cbc.cc
+++ b/tools/cbc.cc
@@ -45,10 +45,10 @@ printKeyCasStatus(string& key, int cbtype, const lcb_RESPBASE *resp,
     if (message != NULL) {
         fprintf(stderr, "%s ", message);
     }
-    fprintf(stderr, "CAS=0x%"PRIx64"\n", resp->cas);
+    fprintf(stderr, "CAS=0x%" PRIx64 "\n", resp->cas);
     const lcb_MUTATION_TOKEN *st = lcb_resp_get_mutation_token(cbtype, resp);
     if (st != NULL) {
-        fprintf(stderr, "%-20sSYNCTOKEN=%u,%"PRIu64",%"PRIu64"\n",
+        fprintf(stderr, "%-20sSYNCTOKEN=%u,%" PRIu64 ",%" PRIu64 "\n",
             "", st->vbid_, st->uuid_, st->seqno_);
     }
 }
@@ -59,7 +59,7 @@ get_callback(lcb_t, lcb_CALLBACKTYPE, const lcb_RESPGET *resp)
 {
     string key = getRespKey((const lcb_RESPBASE *)resp);
     if (resp->rc == LCB_SUCCESS) {
-        fprintf(stderr, "%-20s CAS=0x%"PRIx64", Flags=0x%x. Size=%lu\n",
+        fprintf(stderr, "%-20s CAS=0x%" PRIx64 ", Flags=0x%x. Size=%lu\n",
             key.c_str(), resp->cas, resp->itmflags, (unsigned long)resp->nvalue);
         fflush(stderr);
         fwrite(resp->value, 1, resp->nvalue, stdout);
@@ -135,7 +135,7 @@ observe_callback(lcb_t, lcb_CALLBACKTYPE, const lcb_RESPOBSERVE *resp)
     string key = getRespKey((const lcb_RESPBASE *)resp);
     if (resp->rc == LCB_SUCCESS) {
         fprintf(stderr,
-            "%-20s [%s] Status=0x%x, CAS=0x%"PRIx64"\n", key.c_str(),
+            "%-20s [%s] Status=0x%x, CAS=0x%" PRIx64 "\n", key.c_str(),
             resp->ismaster ? "Master" : "Replica",
                     resp->status, resp->cas);
     } else {
@@ -161,11 +161,11 @@ obseqno_callback(lcb_t, lcb_CALLBACKTYPE, const lcb_RESPOBSEQNO *resp)
         seq_disk = resp->persisted_seqno;
         seq_mem = resp->mem_seqno;
     }
-    fprintf(stderr, "[%d] UUID=0x%"PRIx64", Cache=%"PRIu64", Disk=%"PRIu64,
+    fprintf(stderr, "[%d] UUID=0x%" PRIx64 ", Cache=%" PRIu64 ", Disk=%" PRIu64,
         ix, uuid, seq_mem, seq_disk);
     if (resp->old_uuid) {
         fprintf(stderr, "\n");
-        fprintf(stderr, "    FAILOVER. New: UUID=%"PRIx64", Cache=%"PRIu64", Disk=%"PRIu64,
+        fprintf(stderr, "    FAILOVER. New: UUID=%" PRIx64 ", Cache=%" PRIu64 ", Disk=%" PRIu64,
             resp->cur_uuid, resp->mem_seqno, resp->persisted_seqno);
     }
     fprintf(stderr, "\n");
@@ -234,7 +234,7 @@ arithmetic_callback(lcb_t, lcb_CALLBACKTYPE type, const lcb_RESPCOUNTER *resp)
         printKeyError(key, resp->rc);
     } else {
         char buf[4096] = { 0 };
-        sprintf(buf, "Current value is %"PRIu64".", resp->value);
+        sprintf(buf, "Current value is %" PRIu64 ".", resp->value);
         printKeyCasStatus(key, type, (const lcb_RESPBASE *)resp, buf);
     }
 }
@@ -707,7 +707,7 @@ UnlockHandler::run()
         const string& key = args[ii];
         lcb_CAS cas;
         int rv;
-        rv = sscanf(args[ii+1].c_str(), "0x%"PRIx64, &cas);
+        rv = sscanf(args[ii+1].c_str(), "0x%" PRIx64, &cas);
         if (rv != 1) {
             throw "CAS must be formatted as a hex string beginning with '0x'";
         }


### PR DESCRIPTION
Apparently MACROs now require whitespace around them.