### PR TITLE
[2.7.3] fix build with OpenSSL 1.1

### DIFF
--- a/src/ssl/ssl_common.c
+++ b/src/ssl/ssl_common.c
@@ -156,7 +156,9 @@ iotssl_log_errors(lcbio_XSSL *xs)
         if (ERR_GET_LIB(curerr) == ERR_LIB_SSL) {
             switch (ERR_GET_REASON(curerr)) {
             case SSL_R_CERTIFICATE_VERIFY_FAILED:
+#ifdef SSL_R_MISSING_VERIFY_MESSAGE
             case SSL_R_MISSING_VERIFY_MESSAGE:
+#endif
                 xs->errcode = LCB_SSL_CANTVERIFY;
                 break;
 


### PR DESCRIPTION
```
/builddir/build/BUILD/libcouchbase-2.7.3/src/ssl/ssl_common.c: In function 'iotssl_log_errors':
/builddir/build/BUILD/libcouchbase-2.7.3/src/ssl/ssl_common.c:159:18: error: 'SSL_R_MISSING_VERIFY_MESSAGE' undeclared (first use in this function); did you mean 'SSL_R_MISSING_SRP_PARAM'?
             case SSL_R_MISSING_VERIFY_MESSAGE:
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                  SSL_R_MISSING_SRP_PARAM
```