### PR TITLE
possible memory leak in timer create function

### DIFF
--- a/src/legacy.c
+++ b/src/legacy.c
@@ -105,6 +105,7 @@ lcb_timer_t lcb_timer_create(lcb_t instance, const void *command_cookie, lcb_uin
         return NULL;
     }
     if (!callback) {
+        free(tmr);
         *error = LCB_EINVAL;
         return NULL;
     }


### PR DESCRIPTION
One error branch does not clean up allocated memory for timer