### PR TITLE
(misc) Random seed generater does not need to be alive as static thread_local

### DIFF
--- a/src/rnd.cc
+++ b/src/rnd.cc
@@ -46,8 +46,7 @@ lcb_U64 lcb_next_rand64(void)
 LCB_INTERNAL_API
 lcb_U32 lcb_next_rand32(void)
 {
-    static thread_local std::random_device rd;
-    static thread_local std::mt19937 gen(rd());
+    static thread_local std::mt19937 gen { std::random_device { } () };
     std::uniform_int_distribution< lcb_U32 > dis;
     return dis(gen);
 }
@@ -55,8 +54,7 @@ lcb_U32 lcb_next_rand32(void)
 LCB_INTERNAL_API
 lcb_U64 lcb_next_rand64(void)
 {
-    static thread_local std::random_device rd;
-    static thread_local std::mt19937 gen(rd());
+    static thread_local std::mt19937 gen { std::random_device { } () };
     std::uniform_int_distribution< lcb_U64 > dis;
     return dis(gen);
 }


### PR DESCRIPTION
The `std::random_device rd` will be used only once at the initialization phase of `gen` variable. It'll only consume the RAM even if it stays alive as a static thread_local variable.

##### Reference
- https://issues.couchbase.com/browse/CCBC-963